### PR TITLE
Update configurations to use IAM role for clustering

### DIFF
--- a/modules/is/manifests/params.pp
+++ b/modules/is/manifests/params.pp
@@ -103,9 +103,11 @@ class is::params {
   $transport_sender_trust_store_type = 'JKS'
   $transport_sender_trust_store_password = 'wso2carbon'
 
+  #------------clustering--------------
   $aws_access_key = 'ACCESS_KEY'
   $aws_secret_key = 'SECRET_KEY'
   $aws_region = 'REGION_NAME'
+  $aws_iam_role = 'IAM_ROLE'
   $local_member_host = 'LOCAL-MEMBER-HOST'
   $aws_security_group = 'WSO2SecurityGroup'
   $aws_tag_key = 'cluster'

--- a/modules/is/templates/carbon-home/repository/conf/axis2/axis2.xml.erb
+++ b/modules/is/templates/carbon-home/repository/conf/axis2/axis2.xml.erb
@@ -467,8 +467,9 @@
                     Service (GMS) using a TCP ping mechanism.
         -->
         <parameter name="membershipScheme">aws</parameter>
-        <parameter name="accessKey"><%= @aws_access_key %></parameter>
-        <parameter name="secretKey"><%= @aws_secret_key %></parameter>
+        <parameter name="iamRole"><%= @aws_iam_role %></parameter>
+<!--        <parameter name="accessKey"><%#= @aws_access_key %></parameter>-->
+<!--        <parameter name="secretKey"><%#= @aws_secret_key %></parameter>-->
         <parameter name="securityGroup"><%= @aws_security_group %></parameter>
         <parameter name="region"><%= @aws_region %></parameter>
         <parameter name="tagKey"><%= @aws_tag_key%></parameter>


### PR DESCRIPTION
## Purpose
> Update clustering configurations to use IAM role for hazelcast clustering.

## Goals
> Update clustering configurations to use IAM role for hazelcast clustering.

## Approach
> Add new clustering parameter iamRole in axis2.xml configuration file. Remove accessKey and secretKey parameters.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes